### PR TITLE
Tidy and customise flags

### DIFF
--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -243,8 +243,8 @@ def _impl(ctx):
                             "-Wall",
                             "-Wthread-safety",
                             "-Wself-assign",
-                            "-ffunction-sections",
-                            "-fdata-sections",
+                            # Wayve
+                            "-Werror",
                         ],
                     ),
                 ],
@@ -272,7 +272,14 @@ def _impl(ctx):
             ),
             flag_set(
                 actions = all_cpp_compile_actions,
-                flag_groups = [flag_group(flags = ["-std=c++17", "-stdlib=libstdc++"])],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-std=c++17",
+                            "-stdlib=libstdc++",
+                        ]
+                    )
+                ],
             ),
         ],
     )

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -182,30 +182,6 @@ def _impl(ctx):
     libstdcpp_feature = feature(name = "libstdc++", enabled = True, provides = ["cpp_standard_library"])
     libcpp_feature = feature(name = "libc++", enabled = False, provides = ["cpp_standard_library"])
 
-    unfiltered_compile_flags_feature = feature(
-        name = "unfiltered_compile_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = [
-                            # Do not resolve our symlinked resource prefixes to real paths.
-                            "-no-canonical-prefixes",
-                            # Reproducibility
-                            "-Wno-builtin-macro-redefined",
-                            "-D__DATE__=\"redacted\"",
-                            "-D__TIMESTAMP__=\"redacted\"",
-                            "-D__TIME__=\"redacted\"",
-                            "-fdebug-prefix-map=%{toolchain_path_prefix}=%{debug_toolchain_path_prefix}",
-                        ],
-                    ),
-                ],
-            ),
-        ],
-    )
-
     default_link_flags_feature = feature(
         name = "default_link_flags",
         enabled = True,
@@ -243,6 +219,30 @@ def _impl(ctx):
                 actions = all_link_actions,
                 flag_groups = [flag_group(flags = ["-lc++"])],
                 with_features = [with_feature_set(features = ["libc++"])],
+            ),
+        ],
+    )
+
+    unfiltered_compile_flags_feature = feature(
+        name = "unfiltered_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            # Do not resolve our symlinked resource prefixes to real paths.
+                            "-no-canonical-prefixes",
+                            # Reproducibility
+                            "-Wno-builtin-macro-redefined",
+                            "-D__DATE__=\"redacted\"",
+                            "-D__TIMESTAMP__=\"redacted\"",
+                            "-D__TIME__=\"redacted\"",
+                            "-fdebug-prefix-map=%{toolchain_path_prefix}=%{debug_toolchain_path_prefix}",
+                        ],
+                    ),
+                ],
             ),
         ],
     )
@@ -350,7 +350,7 @@ def _impl(ctx):
     )
 
     cpp_standard_library_compile_flags_feature = feature(
-        name = "cpp_standard_compile_flags",
+        name = "cpp_standard_library_compile_flags",
         enabled = True,
         flag_sets = [
             flag_set(

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -504,6 +504,7 @@ def _impl(ctx):
         unfiltered_compile_flags_feature,
         default_link_flags_feature,
         default_compile_flags_feature,
+        security_compile_flags_feature,
         objcopy_embed_flags_feature,
         user_compile_flags_feature,
         sysroot_feature,

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -155,7 +155,6 @@ def _impl(ctx):
             "-Wl,--build-id=md5",
             "-Wl,--hash-style=gnu",
             "-Wl,-z,relro,-z,now",
-            "-Wl,--gc-sections",
         ]
     elif ctx.attr.cpu == "darwin":
         linker_flags = [

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -329,6 +329,7 @@ def _impl(ctx):
 
     cpp_standard_compile_flags = feature(
         name = "cpp_standard_compile_flags",
+        enabled = True,
         flag_sets = [
             flag_set(
                 actions = all_cpp_compile_actions,

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -546,6 +546,7 @@ def _impl(ctx):
         random_seed_feature,
         supports_pic_feature,
         supports_dynamic_linker_feature,
+        cpp17_feature,
         unfiltered_compile_flags_feature,
         default_link_flags_feature,
         default_compile_flags_feature,

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -229,7 +229,7 @@ def _impl(ctx):
         enabled = True,
         implies = [
             security_compile_flags_feature,
-        ]
+        ],
         flag_sets = [
             flag_set(
                 actions = all_compile_actions,

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -150,7 +150,6 @@ def _impl(ctx):
             "-fuse-ld=lld",
             # The linker has no way of knowing if there are C++ objects; so we always link C++ libraries.
             "-L%{toolchain_path_prefix}/lib",
-            "-lstdc++",
             # Other linker flags.
             "-Wl,--build-id=md5",
             "-Wl,--hash-style=gnu",
@@ -176,7 +175,12 @@ def _impl(ctx):
     supports_pic_feature = feature(name = "supports_pic", enabled = True)
     supports_dynamic_linker_feature = feature(name = "supports_dynamic_linker", enabled = True)
 
-    cpp17_feature = feature(name = "c++17", enabled = True)
+    cpp_standard_feature = feature(name = "cpp_standard", enabled = True)
+    cpp17_feature = feature(name = "c++17", enabled = True, provides = ["cpp_standard"])
+
+    cpp_standard_library_feature = feature(name = "cpp_standard_library", enabled = True)
+    libstdcpp_feature = feature(name = "libstdc++", enabled = True, provides = ["cpp_standard_library"])
+    libcpp_feature = feature(name = "libc++", enabled = False, provides = ["cpp_standard_library"])
 
     unfiltered_compile_flags_feature = feature(
         name = "unfiltered_compile_flags",
@@ -226,19 +230,19 @@ def _impl(ctx):
         ] if ctx.attr.cpu == "k8" else []),
     )
 
-    default_compile_flags_feature = feature(
-        name = "default_compile_flags",
+    cpp_standard_library_link_flags_feature = feature(
+        name = "cpp_standard_link_flags",
         enabled = True,
         flag_sets = [
             flag_set(
-                actions = all_cpp_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = [
-                            "-stdlib=libstdc++",
-                        ]
-                    )
-                ],
+                actions = all_link_actions,
+                flag_groups = [flag_group(flags = ["-lstdc++"])],
+                with_features = [with_feature_set(features = ["libstdc++"])],
+            ),
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [flag_group(flags = ["-lc++"])],
+                with_features = [with_feature_set(features = ["libc++"])],
             ),
         ],
     )
@@ -327,7 +331,7 @@ def _impl(ctx):
         ],
     )
 
-    cpp_standard_compile_flags = feature(
+    cpp_standard_compile_flags_feature = feature(
         name = "cpp_standard_compile_flags",
         enabled = True,
         flag_sets = [
@@ -341,6 +345,23 @@ def _impl(ctx):
                     ),
                 ],
                 with_features = [with_feature_set(features = ["c++17"])],
+            ),
+        ],
+    )
+
+    cpp_standard_library_compile_flags_feature = feature(
+        name = "cpp_standard_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_cpp_compile_actions,
+                flag_groups = [flag_group(flags = ["-stdlib=libstdc++"])],
+                with_features = [with_feature_set(features = ["libstdc++"])],
+            ),
+            flag_set(
+                actions = all_cpp_compile_actions,
+                flag_groups = [flag_group(flags = ["-stdlib=libc++"])],
+                with_features = [with_feature_set(features = ["libc++"])],
             ),
         ],
     )
@@ -546,15 +567,20 @@ def _impl(ctx):
         random_seed_feature,
         supports_pic_feature,
         supports_dynamic_linker_feature,
+        cpp_standard_feature,
         cpp17_feature,
+        cpp_standard_library_feature,
+        libstdcpp_feature,
+        libcpp_feature,
         unfiltered_compile_flags_feature,
         default_link_flags_feature,
-        default_compile_flags_feature,
+        cpp_standard_library_link_flags_feature,
         security_compile_flags_feature,
         pedantry_compile_flags_feature,
         optimisation_compile_flags_feature,
         diagnostic_compile_flags_feature,
-        cpp_standard_compile_flags,
+        cpp_standard_compile_flags_feature,
+        cpp_standard_library_compile_flags_feature
         objcopy_embed_flags_feature,
         user_compile_flags_feature,
         sysroot_feature,

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -224,6 +224,24 @@ def _impl(ctx):
         ] if ctx.attr.cpu == "k8" else []),
     )
 
+    security_compile_flags_feature = feature(
+        name = "security_compile_flags",
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-U_FORTIFY_SOURCE",  # https://github.com/google/sanitizers/issues/247
+                            "-fstack-protector",
+                            "-fno-omit-frame-pointer",
+                        ],
+                    ),
+                ],
+            ),
+        ]
+    )
+
     default_compile_flags_feature = feature(
         name = "default_compile_flags",
         enabled = True,
@@ -280,24 +298,6 @@ def _impl(ctx):
                 ],
             ),
         ],
-    )
-
-    security_compile_flags_feature = feature(
-        name = "security_compile_flags",
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = [
-                            "-U_FORTIFY_SOURCE",  # https://github.com/google/sanitizers/issues/247
-                            "-fstack-protector",
-                            "-fno-omit-frame-pointer",
-                        ],
-                    ),
-                ],
-            ),
-        ]
     )
 
     objcopy_embed_flags_feature = feature(

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -227,16 +227,15 @@ def _impl(ctx):
     default_compile_flags_feature = feature(
         name = "default_compile_flags",
         enabled = True,
+        implies = [
+            security_compile_flags_feature,
+        ]
         flag_sets = [
             flag_set(
                 actions = all_compile_actions,
                 flag_groups = [
                     flag_group(
                         flags = [
-                            # Security
-                            "-U_FORTIFY_SOURCE",  # https://github.com/google/sanitizers/issues/247
-                            "-fstack-protector",
-                            "-fno-omit-frame-pointer",
                             # Diagnostics
                             "-fcolor-diagnostics",
                             "-Wall",
@@ -281,6 +280,24 @@ def _impl(ctx):
                 ],
             ),
         ],
+    )
+
+    security_compile_flags_feature = feature(
+        name = "security_compile_flags",
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-U_FORTIFY_SOURCE",  # https://github.com/google/sanitizers/issues/247
+                            "-fstack-protector",
+                            "-fno-omit-frame-pointer",
+                        ],
+                    ),
+                ],
+            ),
+        ]
     )
 
     objcopy_embed_flags_feature = feature(

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -580,7 +580,7 @@ def _impl(ctx):
         optimisation_compile_flags_feature,
         diagnostic_compile_flags_feature,
         cpp_standard_compile_flags_feature,
-        cpp_standard_library_compile_flags_feature
+        cpp_standard_library_compile_flags_feature,
         objcopy_embed_flags_feature,
         user_compile_flags_feature,
         sysroot_feature,

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -162,6 +162,7 @@ def _impl(ctx):
             "-Wl,--build-id=md5",
             "-Wl,--hash-style=gnu",
             "-Wl,-z,relro,-z,now",
+            "-Wl,--gc-sections",
         ]
     elif ctx.attr.cpu == "darwin":
         linker_flags = [
@@ -249,6 +250,8 @@ def _impl(ctx):
                             "-Wall",
                             "-Wthread-safety",
                             "-Wself-assign",
+                            "-ffunction-sections",
+                            "-fdata-sections",
                         ],
                     ),
                 ],

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -333,9 +333,11 @@ def _impl(ctx):
             flag_set(
                 actions = all_cpp_compile_actions,
                 flag_groups = [
-                    flags = [
-                        "-std=c++17",
-                    ],
+                    flag_group(
+                        flags = [
+                            "-std=c++17",
+                        ],
+                    ),
                 ],
                 with_features = [with_feature_set(features = "c++17")],
             ),
@@ -550,7 +552,7 @@ def _impl(ctx):
         pedantry_compile_flags_feature,
         optimisation_compile_flags_feature,
         diagnostic_compile_flags_feature,
-        cpp_standard_compile_flags
+        cpp_standard_compile_flags,
         objcopy_embed_flags_feature,
         user_compile_flags_feature,
         sysroot_feature,

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -224,29 +224,11 @@ def _impl(ctx):
         ] if ctx.attr.cpu == "k8" else []),
     )
 
-    security_compile_flags_feature = feature(
-        name = "security_compile_flags",
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = [
-                            "-U_FORTIFY_SOURCE",  # https://github.com/google/sanitizers/issues/247
-                            "-fstack-protector",
-                            "-fno-omit-frame-pointer",
-                        ],
-                    ),
-                ],
-            ),
-        ]
-    )
-
     default_compile_flags_feature = feature(
         name = "default_compile_flags",
         enabled = True,
         implies = [
-            security_compile_flags_feature,
+            "security_compile_flags",
         ],
         flag_sets = [
             flag_set(
@@ -298,6 +280,24 @@ def _impl(ctx):
                 ],
             ),
         ],
+    )
+
+    security_compile_flags_feature = feature(
+        name = "security_compile_flags",
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-U_FORTIFY_SOURCE",  # https://github.com/google/sanitizers/issues/247
+                            "-fstack-protector",
+                            "-fno-omit-frame-pointer",
+                        ],
+                    ),
+                ],
+            ),
+        ]
     )
 
     objcopy_embed_flags_feature = feature(

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -339,7 +339,7 @@ def _impl(ctx):
                         ],
                     ),
                 ],
-                with_features = [with_feature_set(features = "c++17")],
+                with_features = [with_feature_set(features = ["c++17"])],
             ),
         ],
     )


### PR DESCRIPTION
This does a lot of work to tidy the existing flags by using "features"

It also adds some flags by default: notably `-Werror` and linking against `libstdc++`

Adds a feature for linking against `libc++`.