### PR TITLE
Feat: Add feature for common C libraries

### DIFF
--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -184,6 +184,8 @@ def _impl(ctx):
     libstdcpp_feature = feature(name = "libstdc++", enabled = True, provides = ["cpp_standard_library"])
     libcpp_feature = feature(name = "libc++", enabled = False, provides = ["cpp_standard_library"])
 
+    common_clibs_feature = feature(name = "common_clibs", enabled = False)
+
     default_link_flags_feature = feature(
         name = "default_link_flags",
         enabled = True,
@@ -224,6 +226,16 @@ def _impl(ctx):
                 with_features = [with_feature_set(features = ["libc++"])],
             ),
         ],
+    )
+
+    common_clibs_link_flags_feature = feature(
+        name = "common_clibs_link_flags",
+        enabled = True,
+        flag_sets = [flag_set(
+            actions = all_link_actions,
+            flag_groups = [flag_group(flags = ["-lpthread", "-lm"])],
+            with_features = [with_feature_set(features = ["common_clibs"])],
+        )],
     )
 
     unfiltered_compile_flags_feature = feature(
@@ -519,9 +531,11 @@ def _impl(ctx):
         cpp_standard_library_feature,
         libstdcpp_feature,
         libcpp_feature,
+        common_clibs_feature,
         unfiltered_compile_flags_feature,
         default_link_flags_feature,
         cpp_standard_library_link_flags_feature,
+        common_clibs_link_flags_feature,
         security_compile_flags_feature,
         pedantry_compile_flags_feature,
         optimisation_compile_flags_feature,


### PR DESCRIPTION
Add a toolchain "feature" for linking against common C libraries. Currently added:
 - libpthread
 - libm